### PR TITLE
fix: collapse assistant bar on first message send

### DIFF
--- a/macai/UI/Chat/ChatView.swift
+++ b/macai/UI/Chat/ChatView.swift
@@ -177,6 +177,13 @@ struct ChatView: View {
                 newMessage = draftManager.draftMessage(for: chat)
             }
         }
+        .onChange(of: chatViewModel.sortedMessages.count) { newCount in
+            if newCount == 1 {
+                withAnimation {
+                    isBottomContainerExpanded = false
+                }
+            }
+        }
         .onChange(of: chat.lastMessage?.body) { _ in
             guard let lastMessage = chat.lastMessage, !lastMessage.own else { return }
             updateReasoningTiming(for: lastMessage, isStreamingActive: logicHandler.isStreaming)
@@ -235,12 +242,6 @@ struct ChatView: View {
         attachedImages = []
         attachedFiles = []
         draftManager.clearDraft(chat: chat)
-
-        if chatViewModel.sortedMessages.count == 1 { // First message just sent
-            withAnimation {
-                isBottomContainerExpanded = false
-            }
-        }
     }
 
     private func handleAddImage() {


### PR DESCRIPTION
Assistant bar collapsing on the first message does not work for me.
This patch fixes it.


https://github.com/user-attachments/assets/ab2aa5f2-cb7b-4be4-b27d-eeb9f24aadec


https://github.com/user-attachments/assets/1b4f7b4f-7846-4bc6-b691-4def6f10e15d

